### PR TITLE
feat(no_std): add helper functions to get the current time

### DIFF
--- a/rs-rtps/Cargo.toml
+++ b/rs-rtps/Cargo.toml
@@ -20,13 +20,13 @@ mio_v06 = { package = "mio", version = "0.6.23" }
 mio_v08 = { package = "mio", version = "0.8.11", features = ["os-poll", "net"] }
 mio-extras = "2.0.6"
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 socket2 = "0.5"
 speedy = "0.8"
 colored = "2.1"
 if-addrs = "0.13"
 cdr = "0.2.4"
-chrono = "0.4.31"
+chrono = { version = "0.4", optional = true }
 thiserror = "1.0"
 serde_repr = "0.1.18"
 
@@ -34,3 +34,7 @@ serde_repr = "0.1.18"
 clap = { version = "4.5", features = ["derive"] }
 clap_derive = "4.5"
 serde_derive = "1.0"
+
+[features]
+default = ["std"]
+std = ["dep:chrono"]

--- a/rs-rtps/src/helper.rs
+++ b/rs-rtps/src/helper.rs
@@ -1,0 +1,27 @@
+static mut NOW: fn() -> Option<i64> = default_now;
+
+#[cfg(feature = "std")]
+fn default_now() -> Option<i64> {
+    chrono::Local::now().timestamp_nanos_opt()
+}
+
+#[cfg(not(feature = "std"))]
+fn default_now() -> Option<i64> {
+    None
+}
+
+/// Set the function to be used to get the current time.
+///
+/// # Safety
+///
+/// `now_fn` must return the number of non-leap-nanoseconds since January 1, 1970 UTC.
+pub unsafe fn set_now_fn(now_fn: fn() -> Option<i64>) {
+    unsafe {
+        NOW = now_fn;
+    }
+}
+
+/// Get the current time in nanoseconds since January 1, 1970 UTC.
+pub fn now() -> Option<i64> {
+    unsafe { NOW() }
+}

--- a/rs-rtps/src/lib.rs
+++ b/rs-rtps/src/lib.rs
@@ -4,5 +4,6 @@ pub mod dds;
 mod rtps;
 use serde::{Deserialize, Serialize};
 mod discovery;
+pub mod helper;
 mod message;
 pub mod structure;

--- a/rs-rtps/src/message/submessage/element.rs
+++ b/rs-rtps/src/message/submessage/element.rs
@@ -17,7 +17,6 @@ use crate::structure::parameter_id::ParameterId;
 use byteorder::ReadBytesExt;
 use bytes::{BufMut, Bytes, BytesMut};
 use cdr::{CdrBe, CdrLe, Infinite, PlCdrBe, PlCdrLe};
-use chrono::Local;
 use serde::{Deserialize, Serialize};
 use speedy::{Context, Readable, Reader, Writable, Writer};
 use std::cmp::{max, min};
@@ -268,7 +267,7 @@ impl Timestamp {
     };
 
     pub fn now() -> Option<Self> {
-        let now = Local::now().timestamp_nanos_opt()?;
+        let now = crate::helper::now()?;
         Some(Self {
             seconds: (now / 1_000_000_000) as u32,
             fraction: (now % 1_000_000_000) as u32,


### PR DESCRIPTION
In a std environment, chrono can be used,
but it is unavailable in no_std environments.
This fix add helper functions for getting the currnet time.