### PR TITLE
use `core` or `alloc` instead of `std` if possible

### DIFF
--- a/UmberDDS/Cargo.lock
+++ b/UmberDDS/Cargo.lock
@@ -98,9 +98,9 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "shlex",
 ]
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -462,18 +462,18 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -543,9 +543,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/UmberDDS/Cargo.toml
+++ b/UmberDDS/Cargo.toml
@@ -36,7 +36,7 @@ serde_repr = "0.1.18"
 [dev-dependencies]
 clap = { version = "4.5", features = ["derive"] }
 clap_derive = "4.5"
-serde_derive = "1.0"
+serde_derive = "1"
 
 [features]
 default = ["std"]

--- a/UmberDDS/src/dds/datareader.rs
+++ b/UmberDDS/src/dds/datareader.rs
@@ -1,12 +1,13 @@
 use crate::dds::{qos::DataReadedrQosPolicies, subscriber::Subscriber, topic::Topic};
 use crate::discovery::structure::cdr::deserialize;
 use crate::rtps::cache::HistoryCache;
+use alloc::sync::Arc;
+use core::marker::PhantomData;
 use mio_extras::channel as mio_channel;
 use mio_v06::{event::Evented, Poll, PollOpt, Ready, Token};
 use serde::Deserialize;
 use std::io;
-use std::marker::PhantomData;
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 
 pub struct DataReader<D: for<'de> Deserialize<'de>> {
     data_phantom: PhantomData<D>,

--- a/UmberDDS/src/dds/datawriter.rs
+++ b/UmberDDS/src/dds/datawriter.rs
@@ -1,9 +1,9 @@
 use crate::dds::{publisher::Publisher, qos::DataWriterQosPolicies, topic::Topic};
 use crate::message::submessage::element::{RepresentationIdentifier, SerializedPayload};
 use crate::rtps::writer::*;
+use core::marker::PhantomData;
 use mio_extras::channel as mio_channel;
 use serde::Serialize;
-use std::marker::PhantomData;
 
 pub struct DataWriter<D: Serialize> {
     data_phantom: PhantomData<D>,

--- a/UmberDDS/src/dds/event_loop.rs
+++ b/UmberDDS/src/dds/event_loop.rs
@@ -7,13 +7,13 @@ use crate::discovery::{
 use crate::rtps::reader::{Reader, ReaderIngredients};
 use crate::rtps::writer::{Writer, WriterIngredients};
 use crate::structure::{entity::RTPSEntity, entity_id::EntityId, guid::*};
+use alloc::collections::BTreeMap;
+use alloc::rc::Rc;
 use bytes::BytesMut;
 use colored::*;
 use mio_extras::{channel as mio_channel, timer::Timer};
 use mio_v06::net::UdpSocket;
 use mio_v06::{Events, Poll, PollOpt, Ready, Token};
-use std::collections::HashMap;
-use std::rc::Rc;
 
 use crate::message::message_receiver::*;
 use crate::message::submessage::element::Locator;
@@ -25,7 +25,7 @@ const MESSAGE_BUFFER_ALLOCATION_CHUNK: usize = 256 * 1024;
 pub struct EventLoop {
     domain_id: u16,
     poll: Poll,
-    sockets: HashMap<Token, UdpSocket>,
+    sockets: BTreeMap<Token, UdpSocket>,
     message_receiver: MessageReceiver,
     add_writer_receiver: mio_channel::Receiver<WriterIngredients>,
     add_reader_receiver: mio_channel::Receiver<ReaderIngredients>,
@@ -35,8 +35,8 @@ pub struct EventLoop {
     set_reader_hb_timer_receiver: mio_channel::Receiver<(EntityId, GUID)>,
     set_writer_nack_timer_sender: mio_channel::Sender<(EntityId, GUID)>,
     set_writer_nack_timer_receiver: mio_channel::Receiver<(EntityId, GUID)>,
-    writers: HashMap<EntityId, Writer>,
-    readers: HashMap<EntityId, Reader>,
+    writers: BTreeMap<EntityId, Writer>,
+    readers: BTreeMap<EntityId, Reader>,
     sender: Rc<UdpSender>,
     writer_hb_timer: Timer<EntityId>,
     reader_hb_timers: Vec<Timer<(EntityId, GUID)>>, // (reader EntityId, writer GUID)
@@ -48,7 +48,7 @@ pub struct EventLoop {
 impl EventLoop {
     pub fn new(
         domain_id: u16,
-        mut sockets: HashMap<Token, UdpSocket>,
+        mut sockets: BTreeMap<Token, UdpSocket>,
         participant_guidprefix: GuidPrefix,
         mut add_writer_receiver: mio_channel::Receiver<WriterIngredients>,
         mut add_reader_receiver: mio_channel::Receiver<ReaderIngredients>,
@@ -123,8 +123,8 @@ impl EventLoop {
             set_reader_hb_timer_receiver,
             set_writer_nack_timer_sender,
             set_writer_nack_timer_receiver,
-            writers: HashMap::new(),
-            readers: HashMap::new(),
+            writers: BTreeMap::new(),
+            readers: BTreeMap::new(),
             sender,
             writer_hb_timer,
             reader_hb_timers: Vec::new(),

--- a/UmberDDS/src/dds/participant.rs
+++ b/UmberDDS/src/dds/participant.rs
@@ -27,15 +27,14 @@ use crate::{
         topic_kind::TopicKind,
     },
 };
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
+use core::net::Ipv4Addr;
+use core::sync::atomic::{AtomicU32, Ordering};
 use mio_extras::channel as mio_channel;
 use mio_v06::net::UdpSocket;
 use rand::rngs::SmallRng;
-use std::collections::HashMap;
-use std::net::Ipv4Addr;
-use std::sync::{
-    atomic::{AtomicU32, Ordering},
-    Arc, Mutex, RwLock,
-};
+use std::sync::{Mutex, RwLock};
 use std::thread::{self, Builder};
 
 #[derive(Clone)]
@@ -318,7 +317,7 @@ impl DomainParticipantInner {
         reader_add_sender: mio_channel::Sender<(EntityId, DiscoveredReaderData)>,
         small_rng: &mut SmallRng,
     ) -> DomainParticipantInner {
-        let mut socket_list: HashMap<mio_v06::Token, UdpSocket> = HashMap::new();
+        let mut socket_list: BTreeMap<mio_v06::Token, UdpSocket> = BTreeMap::new();
         let spdp_multi_socket = new_multicast(
             "0.0.0.0",
             spdp_multicast_port(domain_id),

--- a/UmberDDS/src/dds/publisher.rs
+++ b/UmberDDS/src/dds/publisher.rs
@@ -14,8 +14,9 @@ use crate::structure::{
     entity_id::{EntityId, EntityKind},
     guid::GUID,
 };
+use alloc::sync::Arc;
 use mio_extras::channel as mio_channel;
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 
 #[derive(Clone)]
 pub struct Publisher {

--- a/UmberDDS/src/dds/subscriber.rs
+++ b/UmberDDS/src/dds/subscriber.rs
@@ -14,9 +14,10 @@ use crate::structure::{
     entity_id::{EntityId, EntityKind},
     guid::GUID,
 };
+use alloc::sync::Arc;
 use mio_extras::channel as mio_channel;
 use serde::Deserialize;
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 
 #[derive(Clone)]
 pub struct Subscriber {

--- a/UmberDDS/src/dds/topic.rs
+++ b/UmberDDS/src/dds/topic.rs
@@ -4,7 +4,7 @@ use crate::discovery::structure::data::{
     PublicationBuiltinTopicData, SubscriptionBuiltinTopicData,
 };
 use crate::structure::topic_kind::TopicKind;
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 #[derive(Clone)]
 pub struct Topic {

--- a/UmberDDS/src/discovery/discovery.rs
+++ b/UmberDDS/src/discovery/discovery.rs
@@ -28,11 +28,11 @@ use crate::structure::{
     duration::Duration, entity::RTPSEntity, entity_id::EntityId, guid::GuidPrefix,
     topic_kind::TopicKind, vendor_id::VendorId,
 };
+use alloc::collections::BTreeMap;
 use colored::*;
 use enumflags2::make_bitflags;
 use mio_extras::{channel as mio_channel, timer::Timer};
 use mio_v06::{Events, Poll, PollOpt, Ready, Token};
-use std::collections::HashMap;
 use std::time::Duration as StdDuration;
 
 // SPDPbuiltinParticipantWriter
@@ -65,9 +65,9 @@ pub struct Discovery {
     sedp_builtin_sub_writer: DataWriter<DiscoveredReaderData>,
     sedp_builtin_sub_reader: DataReader<SDPBuiltinData>,
     spdp_send_timer: Timer<()>,
-    writers_data: HashMap<EntityId, DiscoveredWriterData>,
+    writers_data: BTreeMap<EntityId, DiscoveredWriterData>,
     writer_add_receiver: mio_channel::Receiver<(EntityId, DiscoveredWriterData)>,
-    readers_data: HashMap<EntityId, DiscoveredReaderData>,
+    readers_data: BTreeMap<EntityId, DiscoveredReaderData>,
     reader_add_receiver: mio_channel::Receiver<(EntityId, DiscoveredReaderData)>,
 }
 
@@ -214,9 +214,9 @@ impl Discovery {
             sedp_builtin_sub_writer,
             sedp_builtin_sub_reader,
             spdp_send_timer,
-            writers_data: HashMap::new(),
+            writers_data: BTreeMap::new(),
             writer_add_receiver,
-            readers_data: HashMap::new(),
+            readers_data: BTreeMap::new(),
             reader_add_receiver,
         }
     }

--- a/UmberDDS/src/discovery/discovery_db.rs
+++ b/UmberDDS/src/discovery/discovery_db.rs
@@ -1,8 +1,9 @@
 use crate::discovery::structure::data::SPDPdiscoveredParticipantData;
 use crate::message::submessage::element::Timestamp;
 use crate::structure::guid::GuidPrefix;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
+use std::sync::Mutex;
 
 #[derive(Clone)]
 pub struct DiscoveryDB {
@@ -32,13 +33,13 @@ impl DiscoveryDB {
 }
 
 struct DiscoveryDBInner {
-    data: HashMap<GuidPrefix, (Timestamp, SPDPdiscoveredParticipantData)>,
+    data: BTreeMap<GuidPrefix, (Timestamp, SPDPdiscoveredParticipantData)>,
 }
 
 impl DiscoveryDBInner {
     fn new() -> Self {
         Self {
-            data: HashMap::new(),
+            data: BTreeMap::new(),
         }
     }
 

--- a/UmberDDS/src/lib.rs
+++ b/UmberDDS/src/lib.rs
@@ -8,3 +8,5 @@ mod error;
 pub mod helper;
 mod message;
 pub mod structure;
+
+extern crate alloc;

--- a/UmberDDS/src/message/message_receiver.rs
+++ b/UmberDDS/src/message/message_receiver.rs
@@ -12,10 +12,12 @@ use crate::rtps::{
 };
 use crate::structure::entity_id::EntityId;
 use crate::structure::{guid::*, vendor_id::*};
+use alloc::collections::BTreeMap;
+use alloc::fmt;
+use alloc::sync::Arc;
 use colored::*;
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
-use std::{error, fmt};
+use std::error;
+use std::sync::RwLock;
 
 #[derive(Debug, Clone)]
 struct MessageError(String);
@@ -73,8 +75,8 @@ impl MessageReceiver {
     pub fn handle_packet(
         &mut self,
         messages: Vec<UdpMessage>,
-        mut writers: &mut HashMap<EntityId, Writer>,
-        mut readers: &mut HashMap<EntityId, Reader>,
+        mut writers: &mut BTreeMap<EntityId, Writer>,
+        mut readers: &mut BTreeMap<EntityId, Reader>,
     ) {
         for message in messages {
             // Is DDSPING
@@ -110,8 +112,8 @@ impl MessageReceiver {
     fn handle_parsed_packet(
         &mut self,
         rtps_msg: Message,
-        mut writers: &mut HashMap<EntityId, Writer>,
-        mut readers: &mut HashMap<EntityId, Reader>,
+        mut writers: &mut BTreeMap<EntityId, Writer>,
+        mut readers: &mut BTreeMap<EntityId, Reader>,
     ) {
         self.reset();
         self.dest_guid_prefix = self.own_guid_prefix;
@@ -137,8 +139,8 @@ impl MessageReceiver {
     fn handle_entity_submessage(
         &mut self,
         entity_subm: EntitySubmessage,
-        mut writers: &mut HashMap<EntityId, Writer>,
-        mut readers: &mut HashMap<EntityId, Reader>,
+        mut writers: &mut BTreeMap<EntityId, Writer>,
+        mut readers: &mut BTreeMap<EntityId, Reader>,
     ) -> Result<(), MessageError> {
         match entity_subm {
             EntitySubmessage::AckNack(acknack, flags) => {
@@ -222,7 +224,7 @@ impl MessageReceiver {
         &self,
         ackanck: AckNack,
         _flag: BitFlags<AckNackFlag>,
-        writers: &mut HashMap<EntityId, Writer>,
+        writers: &mut BTreeMap<EntityId, Writer>,
     ) -> Result<(), MessageError> {
         // rtps 2.3 spec 8.3.7. AckNack
 
@@ -264,8 +266,8 @@ impl MessageReceiver {
         &mut self,
         data: Data,
         flag: BitFlags<DataFlag>,
-        readers: &mut HashMap<EntityId, Reader>,
-        writers: &mut HashMap<EntityId, Writer>,
+        readers: &mut BTreeMap<EntityId, Reader>,
+        writers: &mut BTreeMap<EntityId, Writer>,
     ) -> Result<(), MessageError> {
         // rtps 2.3 spec 8.3.7.2 Data
 
@@ -531,7 +533,7 @@ impl MessageReceiver {
         &self,
         gap: Gap,
         flag: BitFlags<GapFlag>,
-        readers: &mut HashMap<EntityId, Reader>,
+        readers: &mut BTreeMap<EntityId, Reader>,
     ) -> Result<(), MessageError> {
         // rtps 2.3 spec 8.3.7.4 Gap
 
@@ -579,7 +581,7 @@ impl MessageReceiver {
         &self,
         heartbeat: Heartbeat,
         flag: BitFlags<HeartbeatFlag>,
-        readers: &mut HashMap<EntityId, Reader>,
+        readers: &mut BTreeMap<EntityId, Reader>,
     ) -> Result<(), MessageError> {
         // rtps 2.3 spec 8.3.7.5 Heartbeat
 

--- a/UmberDDS/src/message/submessage.rs
+++ b/UmberDDS/src/message/submessage.rs
@@ -2,8 +2,8 @@ pub mod element;
 pub mod submessage_flag;
 pub mod submessage_header;
 use crate::message::submessage::submessage_header::*;
+use alloc::{fmt, fmt::Debug};
 use speedy::{Context, Writable, Writer};
-use std::{fmt, fmt::Debug};
 
 use crate::message::submessage::element::{
     acknack::AckNack, data::Data, datafrag::DataFrag, gap::Gap, heartbeat::Heartbeat,

--- a/UmberDDS/src/message/submessage/element.rs
+++ b/UmberDDS/src/message/submessage/element.rs
@@ -14,17 +14,17 @@ pub mod nackfrag;
 use crate::network::net_util::get_local_interfaces;
 use crate::structure::duration::Duration;
 use crate::structure::parameter_id::ParameterId;
+use alloc::fmt;
 use byteorder::ReadBytesExt;
 use bytes::{BufMut, Bytes, BytesMut};
 use cdr::{CdrBe, CdrLe, Infinite, PlCdrBe, PlCdrLe};
+use core::cmp::{max, min};
+use core::net::IpAddr;
+use core::ops::{Add, AddAssign};
+use core::ops::{Sub, SubAssign};
 use serde::{Deserialize, Serialize};
 use speedy::{Context, Readable, Reader, Writable, Writer};
-use std::cmp::{max, min};
-use std::fmt;
 use std::io;
-use std::net::IpAddr;
-use std::ops::{Add, AddAssign};
-use std::ops::{Sub, SubAssign};
 
 // spec 9.4.2 Mapping of the PIM SubmessageElements
 

--- a/UmberDDS/src/rtps/cache.rs
+++ b/UmberDDS/src/rtps/cache.rs
@@ -1,6 +1,6 @@
 use crate::message::submessage::element::{SequenceNumber, SerializedPayload};
 use crate::structure::guid::GUID;
-use std::collections::HashMap;
+use alloc::collections::BTreeMap;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct CacheChange {
@@ -109,7 +109,7 @@ pub enum ChangeKind {
 pub struct InstantHandle {/* TODO */}
 
 pub struct HistoryCache {
-    pub changes: HashMap<SequenceNumber, CacheChange>,
+    pub changes: BTreeMap<SequenceNumber, CacheChange>,
     pub min_seq_num: Option<SequenceNumber>,
     pub max_seq_num: Option<SequenceNumber>,
 }
@@ -117,7 +117,7 @@ pub struct HistoryCache {
 impl HistoryCache {
     pub fn new() -> Self {
         Self {
-            changes: HashMap::new(),
+            changes: BTreeMap::new(),
             min_seq_num: None,
             max_seq_num: None,
         }
@@ -147,7 +147,7 @@ impl HistoryCache {
         }
     }
     pub fn remove_changes(&mut self) {
-        self.changes = HashMap::new();
+        self.changes = BTreeMap::new();
         self.min_seq_num = None;
         self.max_seq_num = None;
     }

--- a/UmberDDS/src/rtps/reader.rs
+++ b/UmberDDS/src/rtps/reader.rs
@@ -15,15 +15,16 @@ use crate::structure::{
     proxy::{ReaderProxy, WriterProxy},
     topic_kind::TopicKind,
 };
+use alloc::collections::BTreeMap;
+use alloc::rc::Rc;
+use alloc::sync::Arc;
 use colored::*;
+use core::net::Ipv4Addr;
+use core::time::Duration as StdDuration;
 use enumflags2::BitFlags;
 use mio_extras::channel as mio_channel;
 use speedy::{Endianness, Writable};
-use std::collections::HashMap;
-use std::net::Ipv4Addr;
-use std::rc::Rc;
-use std::sync::{Arc, RwLock};
-use std::time::Duration as StdDuration;
+use std::sync::RwLock;
 
 /// RTPS StatefulReader
 pub struct Reader {
@@ -39,7 +40,7 @@ pub struct Reader {
     heartbeat_response_delay: Duration,
     reader_cache: Arc<RwLock<HistoryCache>>,
     // StatefulReader
-    matched_writers: HashMap<GUID, WriterProxy>,
+    matched_writers: BTreeMap<GUID, WriterProxy>,
     // This implementation spesific
     topic: Topic,
     endianness: Endianness,
@@ -63,7 +64,7 @@ impl Reader {
             expectsinline_qos: ri.expectsinline_qos,
             heartbeat_response_delay: ri.heartbeat_response_delay,
             reader_cache: ri.rhc,
-            matched_writers: HashMap::new(),
+            matched_writers: BTreeMap::new(),
             topic: ri.topic,
             endianness: Endianness::LittleEndian,
             reader_ready_notifier: ri.reader_ready_notifier,

--- a/UmberDDS/src/rtps/writer.rs
+++ b/UmberDDS/src/rtps/writer.rs
@@ -20,15 +20,16 @@ use crate::structure::{
     proxy::{ReaderProxy, WriterProxy},
     topic_kind::TopicKind,
 };
+use alloc::collections::BTreeMap;
+use alloc::rc::Rc;
+use alloc::sync::Arc;
 use colored::*;
+use core::net::Ipv4Addr;
+use core::time::Duration as CoreDuration;
 use mio_extras::channel as mio_channel;
 use mio_v06::Token;
 use speedy::{Endianness, Writable};
-use std::collections::HashMap;
-use std::net::Ipv4Addr;
-use std::rc::Rc;
-use std::sync::{Arc, RwLock};
-use std::time::Duration as StdDuration;
+use std::sync::RwLock;
 
 /// RTPS StatefulWriter
 pub struct Writer {
@@ -50,7 +51,7 @@ pub struct Writer {
     // StatelessWriter
     reader_locators: Vec<ReaderLocator>,
     // StatefulWriter
-    matched_readers: HashMap<GUID, ReaderProxy>,
+    matched_readers: BTreeMap<GUID, ReaderProxy>,
     // This implementation spesific
     topic: Topic,
     endianness: Endianness,
@@ -88,7 +89,7 @@ impl Writer {
             writer_cache: Arc::new(RwLock::new(HistoryCache::new())),
             data_max_size_serialized: wi.data_max_size_serialized,
             reader_locators: Vec::new(),
-            matched_readers: HashMap::new(),
+            matched_readers: BTreeMap::new(),
             topic: wi.topic,
             endianness: Endianness::LittleEndian,
             writer_command_receiver: wi.writer_command_receiver,
@@ -715,15 +716,15 @@ impl Writer {
         self.matched_readers.remove(&guid);
     }
 
-    pub fn heartbeat_period(&self) -> StdDuration {
-        StdDuration::new(
+    pub fn heartbeat_period(&self) -> CoreDuration {
+        CoreDuration::new(
             self.heartbeat_period.seconds as u64,
             self.heartbeat_period.fraction,
         )
     }
 
-    pub fn nack_response_delay(&self) -> StdDuration {
-        StdDuration::new(
+    pub fn nack_response_delay(&self) -> CoreDuration {
+        CoreDuration::new(
             self.nack_response_delay.seconds as u64,
             self.nack_response_delay.fraction,
         )

--- a/UmberDDS/src/structure/duration.rs
+++ b/UmberDDS/src/structure/duration.rs
@@ -1,5 +1,5 @@
+use core::cmp::{Ord, Ordering, PartialOrd};
 use serde::{Deserialize, Serialize};
-use std::cmp::{Ord, Ordering, PartialOrd};
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Duration {

--- a/UmberDDS/src/structure/entity_id.rs
+++ b/UmberDDS/src/structure/entity_id.rs
@@ -1,10 +1,12 @@
 use crate::{Deserialize, Serialize};
+use alloc::fmt;
 use mio_v06::Token;
 use speedy::{Readable, Writable};
-use std::fmt;
 
 // spec 9.2.2
-#[derive(PartialEq, Readable, Writable, Clone, Copy, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    PartialEq, Readable, Writable, Clone, Copy, Eq, Serialize, Deserialize, PartialOrd, Ord,
+)]
 pub struct EntityId {
     entity_key: [u8; 3],
     entity_kind: EntityKind,
@@ -183,7 +185,9 @@ impl fmt::Debug for EntityId {
     }
 }
 
-#[derive(PartialEq, Readable, Writable, Clone, Copy, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    PartialEq, Readable, Writable, Clone, Copy, Eq, Serialize, Deserialize, PartialOrd, Ord,
+)]
 pub struct EntityKind {
     value: u8,
 }

--- a/UmberDDS/src/structure/guid.rs
+++ b/UmberDDS/src/structure/guid.rs
@@ -3,7 +3,7 @@ use rand::{self, rngs::SmallRng, Rng};
 use serde::{Deserialize, Serialize};
 use speedy::{Readable, Writable};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct GUID {
     pub guid_prefix: GuidPrefix,
     pub entity_id: EntityId,
@@ -30,7 +30,9 @@ impl GUID {
     }
 }
 
-#[derive(Readable, Writable, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(
+    Readable, Writable, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord,
+)]
 pub struct GuidPrefix {
     pub guid_prefix: [u8; 12],
 }

--- a/UmberDDS/src/structure/proxy.rs
+++ b/UmberDDS/src/structure/proxy.rs
@@ -4,11 +4,12 @@ use crate::rtps::cache::{
     HistoryCache,
 };
 use crate::structure::{guid::GUID, parameter_id::ParameterId};
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
 use colored::*;
+use core::cmp::{max, min};
 use serde::{ser::SerializeStruct, Serialize};
-use std::cmp::{max, min};
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 
 #[derive(Clone)]
 pub struct ReaderProxy {
@@ -17,7 +18,7 @@ pub struct ReaderProxy {
     pub unicast_locator_list: Vec<Locator>,
     pub multicast_locator_list: Vec<Locator>,
     history_cache: Arc<RwLock<HistoryCache>>,
-    cache_state: HashMap<SequenceNumber, ChangeForReader>,
+    cache_state: BTreeMap<SequenceNumber, ChangeForReader>,
 }
 
 impl ReaderProxy {
@@ -34,7 +35,7 @@ impl ReaderProxy {
             unicast_locator_list,
             multicast_locator_list,
             history_cache,
-            cache_state: HashMap::new(),
+            cache_state: BTreeMap::new(),
         }
     }
 
@@ -188,7 +189,7 @@ pub struct WriterProxy {
     pub multicast_locator_list: Vec<Locator>,
     pub data_max_size_serialized: i32, // in rtps 2.3 spec, Figure 8.30: long
     history_cache: Arc<RwLock<HistoryCache>>,
-    cache_state: HashMap<SequenceNumber, ChangeFromWriter>,
+    cache_state: BTreeMap<SequenceNumber, ChangeFromWriter>,
 }
 
 impl WriterProxy {
@@ -205,7 +206,7 @@ impl WriterProxy {
             multicast_locator_list,
             data_max_size_serialized,
             history_cache,
-            cache_state: HashMap::new(),
+            cache_state: BTreeMap::new(),
         }
     }
 


### PR DESCRIPTION
Fix to use `core` or `alloc` instead of `std` if possible.
Because no_std environments does not support `HashMap`, `HashMap` has been replaced with `BTreeMap`.